### PR TITLE
[#173] Defaulted baseUrl to empty string if undefined

### DIFF
--- a/src/services/ajax-service.js
+++ b/src/services/ajax-service.js
@@ -31,7 +31,7 @@ export default class AjaxService {
         //}
     }
     prepareUrl(url, params) {
-        this._basePath = this.$session.rootUrl;
+        this._basePath = this.$session.rootUrl || '';
         if (!this._basePath.endsWith('/')) {
             this._basePath += '/';
         }


### PR DESCRIPTION
Fixes #173