### PR TITLE
#298 - resolve small worklog timer entries

### DIFF
--- a/src/services/worklog-timer-service.js
+++ b/src/services/worklog-timer-service.js
@@ -144,11 +144,11 @@ export default class WorklogTimerService extends BaseService {
         const minTime = parseTimeInMins(await this.$settings.get('TR_MinTime'));
         if (timeInMins >= minTime) {
 
-            const TR_RoundTime = await this.$settings.get('TR_RoundTime');
-            const TR_RoundOpr = (await this.$settings.get('TR_RoundOpr')) || 5;
+            const TR_RoundTime = (await this.$settings.get('TR_RoundTime')) || 5;
+            const TR_RoundOpr = await this.$settings.get('TR_RoundOpr');
 
             if (TR_RoundOpr && Math[TR_RoundOpr]) {
-                timeInMins = parseInt(Math[TR_RoundOpr](timeInMins / TR_RoundTime) * TR_RoundTime);
+                timeInMins = parseInt(Math.max(1, Math[TR_RoundOpr](timeInMins / TR_RoundTime)) * TR_RoundTime);
             }
 
             if (timeInMins >= 1) {


### PR DESCRIPTION
Found a couple of issues in the math for checking minimum worklog timer time (and hence failing to store the worklog) to resolve my issue create at #298.
1. `TR_RoundTime` should have the `|| 5` default, rather than the operator (since `Math[5]` isn't a function)
2. `timeInMins` will be 0 for anything < 30 seconds, so the rounding operation (e.g. `ceil`) would still keep it as 0 instead of ceiling it to 5 minutes (or what the user has configured). The `Math.max` ensures it is at least 1 minute (if the user has set `TR_MinTime` greater than that then it will never get to this code path anyway from the `if (timeInMins >= minTime)` check above)