### PR TITLE
Decrease play button brightness and size

### DIFF
--- a/src/content-scripts/constants.js
+++ b/src/content-scripts/constants.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 // https://fa2png.app/
-const playIconSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" width="18px" height="18px" fill="#00ff00">
+const playIconSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" width="16px" height="16px" fill="#36B37E">
 <path d="M424.4 214.7L72.4 6.6C43.8-10.3 0 6.1 0 47.9V464c0 37.5 40.7 60.1 72.4 41.3l352-208c31.4-18.5 31.5-64.1 0-82.6z"></path>
 </svg>`;
 export const icons = {


### PR DESCRIPTION
Hello,

Everybody on my team have their eyes burned from the color intensity of the play button, can we make it a little more friendly?
I also changed the size, so it matches the other original jira buttons.

From 
![image](https://github.com/shridhar-tl/jira-assistant/assets/9109378/d8e5e383-5890-4e92-b3b7-774d1af78fb3)

To
![image](https://github.com/shridhar-tl/jira-assistant/assets/9109378/d4825a8b-5660-455c-937a-d784e48d4741)

Cheers !