### PR TITLE
#380 For new worklog report use user defined start of work day

### DIFF
--- a/src/gadgets/WorklogReport/actions.js
+++ b/src/gadgets/WorklogReport/actions.js
@@ -27,7 +27,7 @@ export function groupsChanged(setState) {
 }
 
 export function addWorklog(setState) {
-    const { $session: { CurrentUser: { maxHours } } } = inject('SessionService');
+    const { $session: { CurrentUser: { maxHours }, UserSettings: { startOfDay } } } = inject('SessionService');
     const maxSecsPerDay = (maxHours || 8) * 60 * 60;
 
     return function (user, ticketNo, dateStarted, logged) {
@@ -38,6 +38,8 @@ export function addWorklog(setState) {
 
         if (moment(dateStarted).isSame(moment(), 'day')) {
             dateStarted = new Date();
+        } else if (startOfDay) {
+            dateStarted.setHours(...startOfDay.split(':'))
         }
 
         setState({ showWorklogPopup: true, worklogItem: { ticketNo, dateStarted, timeSpent } });


### PR DESCRIPTION
resolves #380 

when worklog is opened for current day, current time is used when worklog is opened for previous or future day, 00:00 time is used

when employee and employer are placed in different timezones and report is done once in a week or so, it happens, that 00:00 time of employee is previous day of employer

user should have an ability to configure default report time, so he doesn't need to change the time for each ticket of each day during report process