### PR TITLE
Fix: declare missing read:group:jira and read:user:jira scopes for Cloud app

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -88,6 +88,8 @@ permissions:
     - read:avatar:jira
     - read:board-scope.admin:jira-software
     - read:issue.changelog:jira
+    - read:group:jira
+    - read:user:jira
     - write:jira-work
     - write:sprint:jira-software
 app:


### PR DESCRIPTION
## Summary

Fixes #342 and #385.

On the Cloud (Forge) build of Jira Assistant, adding a Jira group from **Settings → User Groups → Add group → Add Jira Group** fails with:

> Unknown error — Unable to pull user list from group. Look at console log for more details.

The browser console / Network tab shows the underlying call to `/rest/api/2/group/member` returning:

```json
{"code":401,"message":"Unauthorized; scope does not match"}
```

## Root cause

`/rest/api/2/group/member` is invoked from `JiraService.getGroupMembers` via `requestJira`. According to the [Atlassian Cloud REST API docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-groups/#api-rest-api-3-group-member-get), this endpoint requires the following **granular** OAuth 2.0 scopes:

- `read:group:jira`
- `read:user:jira`
- `read:avatar:jira`

The current `manifest.yml` only declares `read:avatar:jira`, so the Atlassian API gateway rejects the request before it ever reaches Jira.

The picker call `/rest/api/2/groups/picker` is unaffected because it only requires `read:group:jira` *or* the classic `read:jira-user` (which is already declared). This explains why the autocomplete search works but the confirm step fails — exactly the symptom users have been reporting.

## Fix

Add the two missing granular scopes to `manifest.yml`:

```yaml
- read:group:jira
- read:user:jira
```

`read:avatar:jira` is already declared, so no change is needed there. No JavaScript code is modified.

## Notes for maintainers / users

- This is a manifest-only change.
- Existing site installations will need to be upgraded (`forge install --upgrade --site …`) and the site admin must **Accept** the newly-requested scopes in *Apps → Manage your apps → Review scopes*, otherwise the upgraded install will continue to use the old scope set and still 401.
- Consider also adding an explicit 401 branch to `UserGroup.jsx`'s `addNewGroup` catch so future scope mismatches show a more actionable error instead of "Unknown error" — happy to do this in a follow-up PR if desired.

## Test plan

- [x] Deploy the patched build to a private dev app via `forge deploy`
- [x] `forge install --upgrade --site <test-site>.atlassian.net` and accept the new scopes
- [x] Open Jira Assistant → User Groups → Add group → tick **Add Jira Group** → pick a group → confirm ✓
- [x] Group is added and member list is populated correctly
- [x] Picker autocomplete (`/groups/picker`) still works
- [x] No regression on the browser-extension build (manifest.yml is not bundled there)