### PR TITLE
Fix timer control missing from issue view on Jira DC/Server 10+

### DIFF
--- a/src/content-scripts/jira-issue.ts
+++ b/src/content-scripts/jira-issue.ts
@@ -20,7 +20,16 @@ export function applyIssueLogic(currentPage: string, settings: Settings, firstTi
     if (isCloud) {
         el = $('#jira-issue-header a[data-testid="issue.views.issue-base.foundation.breadcrumbs.current-issue.item"]').parent();
     } else {
+        // Jira DC/Server: the command bar toolbar is an AUI toolbar2. Older Jira nested two <div>
+        // levels here, so the original selector drilled `> div:first-child > div:first-child`.
+        // Since Jira DC 10 the first child of `.aui-toolbar2-inner` is a <ul> (not a <div>), so that
+        // selector matches nothing and the timer control is never injected (upstream issue #425).
+        // Keep the original selector as the primary path (unchanged behaviour on pre-10 Jira) and
+        // fall back to the stable `.aui-toolbar2-inner` container when it finds nothing (DC 10+).
         el = $('div.issue-header-content .command-bar .ops-menus > div:first-child > div:first-child');
+        if (!el.length) {
+            el = $('div.issue-header-content .command-bar .ops-menus .aui-toolbar2-inner');
+        }
     }
 
     if (!el.length) {


### PR DESCRIPTION
## Problem

Fixes #425.

After upgrading a Jira Data Center/Server instance to Jira 10, the worklog **timer control no longer appears** in the issue-view command bar (it used to sit next to the Edit / Comment buttons).

## Root cause

`applyIssueLogic()` locates the DC/Server toolbar with:

```
div.issue-header-content .command-bar .ops-menus > div:first-child > div:first-child
```

In Jira 10 the AUI toolbar structure is:

```
.ops-menus.aui-toolbar2
  └─ div.aui-toolbar2-inner        ← ".ops-menus > div:first-child"  ✓ (a <div>)
       ├─ ul.aui-toolbar2-primary  ← "> div:first-child"  ✗ it's a <ul>, not a <div>
       └─ div.aui-toolbar2-secondary
```

The final `> div:first-child` expects a `<div>`, but the first child of `.aui-toolbar2-inner` is now `<ul class="aui-toolbar2-primary">`. The selector matches nothing, so `el.length === 0` and the function returns early — the timer control is never injected.

## Fix

Keep the original selector as the **primary** lookup (unchanged behaviour on pre-10 Jira, so no regression there) and **fall back** to the stable `.aui-toolbar2-inner` container only when the original finds nothing (Jira 10+):

```js
el = $('div.issue-header-content .command-bar .ops-menus > div:first-child > div:first-child');
if (!el.length) {
    el = $('div.issue-header-content .command-bar .ops-menus .aui-toolbar2-inner');
}
```

## Verification

- Reproduced against a real Jira DC 10.3.x issue page: the original selector returns **0** matches; the fallback returns **1**, and the injected control lands in the same toolbar as the Edit button.
- Built the extension and confirmed the fix in the bundled content script; timer control confirmed working in the issue view on Jira DC 10.
- Backward compatible by construction: pre-10 Jira uses the untouched primary selector.