### PR TITLE
Add missing fs-extra build dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
+        "fs-extra": "^11.3.6",
         "gh-pages": "^6.3.0",
         "globals": "^17.7.0",
         "sass-embedded": "^1.100.0",


### PR DESCRIPTION
## Problem

`post-build.cjs` (run as the `postbuild*` step of every extension/app/web build) does:

```js
const fs = require('fs-extra');
```

and uses APIs that Node's native `fs` does not provide — `copySync`, `moveSync`, `emptyDirSync`, `writeJsonSync`. However `fs-extra` is **not declared anywhere in `package.json`**.

On a clean checkout, `pnpm install && pnpm build` fails during post-build with:

```
Error: Cannot find module 'fs-extra'
    at .../post-build.cjs
```

(It only appears to work in environments where `fs-extra` happens to be hoisted/available from another source.)

## Fix

Declare `fs-extra` in `devDependencies` so the build post-processing works from a fresh clone.