### PR TITLE
Add worklog: keep focus on the ticket field and parse pasted issue links (#383, #319, #304)

### DIFF
--- a/src/jira-controls/IssuePicker.tsx
+++ b/src/jira-controls/IssuePicker.tsx
@@ -11,6 +11,30 @@ import type SessionService from '../services/session-service';
 
 const ignoredKeysStrokes = [9, 16, 17, 18, 27, 123];
 const issueKeyTest = /^\b[A-Z][A-Z0-9_]+-[1-9][0-9]*$/gi;
+const issueKeyInUrl = /[A-Z][A-Z0-9_]+-[1-9][0-9]*/i;
+
+/**
+ * When a Jira issue url is pasted (e.g. https://jira.example.com/browse/ABC-123),
+ * extract and return the issue key; any other text is returned unchanged (issue #304)
+ */
+function extractIssueKey(text: string): string {
+    if (!text || (!text.includes('://') && !text.includes('/browse/'))) {
+        return text;
+    }
+
+    const browseMatch = text.match(/\/browse\/([A-Z][A-Z0-9_]+-[1-9][0-9]*)/i);
+    if (browseMatch) {
+        return browseMatch[1].toUpperCase();
+    }
+
+    const paramMatch = text.match(/[?&](?:selectedIssue|issueKey)=([A-Z][A-Z0-9_]+-[1-9][0-9]*)/i);
+    if (paramMatch) {
+        return paramMatch[1].toUpperCase();
+    }
+
+    const anyKey = text.match(issueKeyInUrl);
+    return anyKey ? anyKey[0].toUpperCase() : text;
+}
 
 interface IssueObject {
     id: string;
@@ -80,6 +104,9 @@ export const IssuePicker: React.FC<IssuePickerProps> = React.memo(
         placeholder = 'Enter issue key or summary',
     }) => {
         const timerRef = useRef<{ blurTimer?: ReturnType<typeof setTimeout> }>({});
+        const editContainerRef = useRef<HTMLDivElement>(null);
+        const displayRef = useRef<HTMLDivElement>(null);
+        const pickedByUserRef = useRef(false);
         const [loading, setLoader] = useState(useDisplay && !!value);
         const [issueObj, setIssue] = useState<IssueObject | false>(
             useDisplay && value ? ({ key: typeof value === 'string' ? value : value.key } as IssueObject) : false,
@@ -121,6 +148,32 @@ export const IssuePicker: React.FC<IssuePickerProps> = React.memo(
                 })();
             }
         }, [value]); // eslint-disable-line react-hooks/exhaustive-deps
+
+        // Focus the input as soon as the picker becomes editable. The autoFocus prop
+        // alone is not reliable when the picker is rendered inside a modal (issue #383)
+        useEffect(() => {
+            if (!useDisplay || !editMode) {
+                return;
+            }
+
+            const handle = setTimeout(() => {
+                const input = editContainerRef.current?.querySelector('input');
+                if (input && document.activeElement !== input) {
+                    input.focus();
+                }
+            }, 50);
+
+            return () => clearTimeout(handle);
+        }, [editMode, useDisplay]);
+
+        // After the user picks a ticket, keep keyboard focus in the flow instead of
+        // dropping it when the input is replaced with the display box (issue #319)
+        useEffect(() => {
+            if (useDisplay && !editMode && issueObj && pickedByUserRef.current) {
+                pickedByUserRef.current = false;
+                displayRef.current?.focus();
+            }
+        }, [editMode, issueObj, useDisplay]);
 
         const handleFilter = useCallback(
             async (query: string) => {
@@ -165,6 +218,7 @@ export const IssuePicker: React.FC<IssuePickerProps> = React.memo(
 
                 const selected = e.value;
                 if (selected && typeof selected === 'object' && selected.key) {
+                    pickedByUserRef.current = true;
                     updateIssue(selected);
                     setSuggestions([]);
                     setTimeout(() => setInputValue(''), 0);
@@ -176,7 +230,7 @@ export const IssuePicker: React.FC<IssuePickerProps> = React.memo(
         const handleChange = useCallback((e: any) => {
             const newVal = e.value;
             if (typeof newVal === 'string') {
-                setInputValue(newVal);
+                setInputValue(extractIssueKey(newVal));
             }
         }, []);
 
@@ -219,7 +273,7 @@ export const IssuePicker: React.FC<IssuePickerProps> = React.memo(
 
         if (editMode || !issueObj || !useDisplay) {
             return (
-                <div onBlur={handleBlur}>
+                <div ref={editContainerRef} onBlur={handleBlur}>
                     <Autocomplete
                         value={inputValue}
                         onChange={handleChange}
@@ -240,8 +294,9 @@ export const IssuePicker: React.FC<IssuePickerProps> = React.memo(
 
         return (
             <div
+                ref={displayRef}
                 className={`flex items-center gap-2 px-3 py-2 border border-(--border-color) rounded-lg cursor-pointer transition-colors hover:bg-(--bg-hover) ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`}
-                tabIndex={tabIndex}
+                tabIndex={tabIndex ?? -1}
                 onClick={disabled ? undefined : () => toggleEdit(true)}
                 onKeyDown={disabled ? undefined : editTicket}
                 data-test-id="issue-key"


### PR DESCRIPTION
Three related papercuts in the Add worklog issue picker, all reported separately.

### #383 — Ticket field does not take focus
The picker passes `autoFocus` to the input, but that does not fire reliably when the
picker is mounted inside a modal, so the dialog opens with nothing focused and you have
to click the field before typing.

Fixed by focusing the input explicitly once the picker becomes editable.

### #319 — Focus is lost after selecting a ticket
Once a ticket is picked, the input is replaced by the read-only display box, and focus
was dropped to the document. Tabbing then restarted from the top of the dialog.

Focus now moves to the display box, so Tab continues to the next field as expected.
Only when the user actually picked something — programmatic value changes do not steal
focus.

### #304 — Pasting a Jira issue link fills in the whole URL
Pasting `https://jira.example.com/browse/ABC-123` put the entire URL in the field, which
then failed validation. The issue key is now extracted from the common shapes:

- `.../browse/ABC-123`
- `...?selectedIssue=ABC-123` and `...?issueKey=ABC-123`
- any other URL containing an issue key, as a fallback

Text that is not a URL is left untouched, so typing a key or a summary is unaffected.

### Scope
One file: `src/jira-controls/IssuePicker.tsx`. No API or storage changes.

### How to verify
1. Open Add worklog — the ticket field is focused, you can type immediately.
2. Pick a ticket from the suggestions, then press Tab — focus continues into the dialog
   rather than jumping to the top.
3. Copy an issue URL from the browser address bar and paste it into the ticket field —
   only the key appears.

Closes #383
Closes #319
Closes #304