### PR TITLE
Holiday and leave support for expected working time (refs #26)

### DIFF
--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -41,14 +41,23 @@ export const sett_page_calendar = {
 
 export const sett_page_reports_UserDayWise = { logFormat: '1', breakupMode: '1', groupMode: '1' };
 
+// Work-schedule defaults. These are the single source of truth: both commonSettings
+// below and SettingsService.settingsDefaultValues read them, so no other place may
+// hardcode competing work-hour values. Declared before first use.
+export const DefaultWorkingDays = [1, 2, 3, 4, 5];
+export const DefaultStartOfDay = '10:00';
+export const DefaultEndOfDay = '19:00';
+export const DefaultMinHours = 8;
+export const DefaultMaxHours = 8;
+
 export const commonSettings = {
     [SettingsCategory.General]: {
         dateFormat: 'dd-MMM-yyyy',
         timeFormat: ' hh:mm:ss tt',
-        minHours: 8,
-        maxHours: 8,
-        startOfDay: '09:00',
-        endOfDay: '17:00',
+        minHours: DefaultMinHours,
+        maxHours: DefaultMaxHours,
+        startOfDay: DefaultStartOfDay,
+        endOfDay: DefaultEndOfDay,
         startOfWeek: 1,
     },
     [SettingsCategory.System]: {
@@ -96,10 +105,6 @@ export const momentizedDateFormats: Record<string, string> = {
 };
 
 export const timeFormats = [' HH:mm:ss', ' hh:mm:ss tt', ' HH.mm.ss', ' hh.mm.ss tt'];
-
-export const DefaultWorkingDays = [1, 2, 3, 4, 5];
-export const DefaultStartOfDay = '10:00';
-export const DefaultEndOfDay = '19:00';
 
 export const TINY_DAY_NAMES = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
 export const SHORT_DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];

--- a/src/pages/settings/general/GeneralSettings.tsx
+++ b/src/pages/settings/general/GeneralSettings.tsx
@@ -9,6 +9,7 @@ import { TabPage, TabView } from '@components';
 
 import DefaultValuesTab from './DefaultValuesTab';
 import GeneralTab from './GeneralTab';
+import HolidaysTab from './HolidaysTab';
 import MeetingsTab from './MeetingsTab';
 import MenuOptionsTab from './MenuOptionsTab';
 import TimeTrackerTab from './TimeTrackerTab';
@@ -88,6 +89,11 @@ export default function GeneralSettings() {
                         <TabPage header="Worklog">
                             <div className="p-4">
                                 <WorklogTab settings={settings} isAtlasCloud={isAtlasCloud} onSave={saveSetting} />
+                            </div>
+                        </TabPage>
+                        <TabPage header="Holidays">
+                            <div className="p-4">
+                                <HolidaysTab settings={settings} onSave={saveSetting} />
                             </div>
                         </TabPage>
                         <TabPage header="Default Values">

--- a/src/pages/settings/general/HolidaysTab.tsx
+++ b/src/pages/settings/general/HolidaysTab.tsx
@@ -1,0 +1,184 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { inject } from '@services';
+
+import { Button, Checkbox, Dropdown, TextInput } from '@components';
+
+import { formatDate } from '@utils';
+
+import type { NonWorkingDay } from '@types';
+
+interface HolidaysTabProps {
+    settings: Record<string, any>;
+    onSave: (value: any, field: string) => void;
+}
+
+const typeOptions = [
+    { value: 'holiday', label: 'Public holiday' },
+    { value: 'leave', label: 'Leave / time off' },
+];
+
+function todayKey(): string {
+    return formatDate(new Date(), 'yyyy-MM-dd');
+}
+
+export default function HolidaysTab({ settings, onSave }: HolidaysTabProps) {
+    const { $userutils } = inject('UserUtilsService');
+
+    const holidays: NonWorkingDay[] = useMemo(() => settings.holidays || [], [settings.holidays]);
+
+    const [newDate, setNewDate] = useState(todayKey);
+    const [newName, setNewName] = useState('');
+    const [newType, setNewType] = useState<'holiday' | 'leave'>('holiday');
+    const [newHalfDay, setNewHalfDay] = useState(false);
+
+    const sorted = useMemo(() => [...holidays].sort((a, b) => a.date.localeCompare(b.date)), [holidays]);
+
+    const persist = useCallback(
+        (list: NonWorkingDay[]) => {
+            onSave(list, 'holidays');
+        },
+        [onSave],
+    );
+
+    const addEntry = useCallback(() => {
+        if (!newDate) {
+            return;
+        }
+
+        const entry: NonWorkingDay = {
+            date: newDate,
+            name: newName.trim() || undefined,
+            type: newType,
+            isHalfDay: newHalfDay || undefined,
+        };
+
+        // Re-adding an existing date replaces it rather than creating a duplicate
+        const list = [...holidays.filter((h) => h.date !== entry.date), entry];
+        persist(list);
+
+        setNewName('');
+        setNewHalfDay(false);
+    }, [newDate, newName, newType, newHalfDay, holidays, persist]);
+
+    const removeEntry = useCallback(
+        (date: string) => {
+            persist(holidays.filter((h) => h.date !== date));
+        },
+        [holidays, persist],
+    );
+
+    const importWeekendsNote = useMemo(() => {
+        const workingDays = settings.workingDays as number[] | undefined;
+        if (!workingDays?.length) {
+            return null;
+        }
+        const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+        const offDays = dayNames.filter((_, i) => !workingDays.includes(i));
+        return offDays.length ? offDays.join(', ') : null;
+    }, [settings.workingDays]);
+
+    return (
+        <div className="divide-y divide-[--border-primary]">
+            <div className="pb-5">
+                <div className="text-sm font-semibold text-[--text-primary] mb-1">Holidays &amp; Leave</div>
+                <p className="text-xs text-[--text-secondary] mb-3">
+                    Days listed here are treated as non-working, so worklog reports and the logging compliance gadget will not flag them as
+                    missing time. Mark a day as half day when you are expected to log half of your normal hours.
+                    {importWeekendsNote && (
+                        <>
+                            {' '}
+                            Your weekends ({importWeekendsNote}) are already excluded through the Working Days setting and need not be listed
+                            here.
+                        </>
+                    )}
+                </p>
+
+                <div className="flex gap-3 items-end flex-wrap mb-4">
+                    <div>
+                        <label className="block text-xs font-medium text-[--text-secondary] mb-1">Date</label>
+                        <input
+                            type="date"
+                            value={newDate}
+                            onChange={(e) => setNewDate(e.target.value)}
+                            className="px-3 py-2 border border-(--border-color) rounded-md text-sm bg-(--bg-primary) text-primary"
+                        />
+                    </div>
+                    <div className="flex-1 min-w-40">
+                        <label className="block text-xs font-medium text-[--text-secondary] mb-1">Description (optional)</label>
+                        <TextInput value={newName} onChange={(e) => setNewName(e.value)} placeholder="e.g. Christmas, Annual leave" />
+                    </div>
+                    <div>
+                        <label className="block text-xs font-medium text-[--text-secondary] mb-1">Type</label>
+                        <Dropdown
+                            className="w-44"
+                            options={typeOptions}
+                            value={newType}
+                            onChange={(e) => setNewType(e.value as 'holiday' | 'leave')}
+                        />
+                    </div>
+                    <div className="pb-2">
+                        <Checkbox checked={newHalfDay} onChange={(e) => setNewHalfDay(e.value)} label="Half day" />
+                    </div>
+                    <Button variant="primary" leftIcon={<i className="fa fa-plus" />} onClick={addEntry} disabled={!newDate}>
+                        Add
+                    </Button>
+                </div>
+
+                {!sorted.length && (
+                    <div className="text-xs text-[--text-secondary] italic">
+                        No holidays or leave configured yet. Only weekends are excluded from expected working time.
+                    </div>
+                )}
+
+                {!!sorted.length && (
+                    <div className="rounded-lg border border-(--border-color) overflow-hidden">
+                        <table className="w-full text-sm">
+                            <thead className="bg-(--bg-secondary)">
+                                <tr>
+                                    <th className="text-left px-3 py-2 font-medium">Date</th>
+                                    <th className="text-left px-3 py-2 font-medium">Description</th>
+                                    <th className="text-left px-3 py-2 font-medium">Type</th>
+                                    <th className="text-left px-3 py-2 font-medium">Expected hours</th>
+                                    <th className="w-12" />
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {sorted.map((h) => (
+                                    <tr key={h.date} className="border-t border-(--border-color)">
+                                        <td className="px-3 py-2 whitespace-nowrap">
+                                            {$userutils.formatDate(new Date(`${h.date}T00:00:00`))}
+                                        </td>
+                                        <td className="px-3 py-2">{h.name || <span className="text-secondary italic">—</span>}</td>
+                                        <td className="px-3 py-2">
+                                            <span
+                                                className={`inline-block px-2 py-0.5 rounded text-xs ${
+                                                    h.type === 'leave'
+                                                        ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
+                                                        : 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+                                                }`}
+                                            >
+                                                {h.type === 'leave' ? 'Leave' : 'Holiday'}
+                                            </span>
+                                        </td>
+                                        <td className="px-3 py-2">{h.isHalfDay ? 'Half day' : 'None'}</td>
+                                        <td className="px-3 py-2 text-right">
+                                            <Button
+                                                layout="plain"
+                                                variant="danger"
+                                                leftIcon={<i className="fa fa-trash" />}
+                                                onClick={() => removeEntry(h.date)}
+                                                title="Remove"
+                                                size="sm"
+                                            />
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/services/settings-service.ts
+++ b/src/services/settings-service.ts
@@ -1,4 +1,13 @@
-import { SystemUserId, dateFormats, timeFormats, DefaultWorkingDays, DefaultStartOfDay, DefaultEndOfDay } from '@/constants';
+import {
+    SystemUserId,
+    dateFormats,
+    timeFormats,
+    DefaultWorkingDays,
+    DefaultStartOfDay,
+    DefaultEndOfDay,
+    DefaultMinHours,
+    DefaultMaxHours,
+} from '@/constants';
 
 import { SettingsCategory } from '@types';
 
@@ -6,10 +15,11 @@ import type StorageService from './storage-service';
 
 const settingsDefaultValues: Record<string, any> = {
     workingDays: DefaultWorkingDays,
+    holidays: [],
     dateFormat: dateFormats[0],
     timeFormat: timeFormats[0],
-    minHours: 8,
-    maxHours: 8,
+    minHours: DefaultMinHours,
+    maxHours: DefaultMaxHours,
     commentLength: 5,
     startOfDay: DefaultStartOfDay,
     endOfDay: DefaultEndOfDay,

--- a/src/services/userutils-service.ts
+++ b/src/services/userutils-service.ts
@@ -1,12 +1,11 @@
+import { DefaultWorkingDays } from '@/constants';
+
 import { differenceInDays, formatDate, getDateArray, getUserName, mergeUrl, viewIssueUrl } from '@utils';
 
-import type { JiraUser, User } from '@types';
+import type { JiraUser, NonWorkingDay, User } from '@types';
 
 import type SessionService from './session-service';
 import type UtilsService from './utils-service';
-
-// Default working days: Monday(1) to Friday(5)
-const DefaultWorkingDays = [1, 2, 3, 4, 5];
 
 export interface DayInfo {
     prop: string;
@@ -14,6 +13,8 @@ export interface DayInfo {
     date: Date;
     isHoliday: boolean;
     isFuture: boolean;
+    /** Set when the day is a configured holiday or leave rather than a weekend */
+    nonWorkingDay?: NonWorkingDay;
 }
 
 export default class UserUtilsService {
@@ -42,7 +43,50 @@ export default class UserUtilsService {
     isHoliday = (date: Date): boolean => {
         const weekDay = date.getDay();
         const workingDays = this.$session.CurrentUser?.workingDays || DefaultWorkingDays;
-        return workingDays.indexOf(weekDay) === -1;
+
+        if (workingDays.indexOf(weekDay) === -1) {
+            return true;
+        }
+
+        // A configured holiday or full-day leave makes a working weekday non-working.
+        // Half days stay working days: some logged time is still expected on them.
+        const entry = this.getNonWorkingDay(date);
+        return !!entry && !entry.isHalfDay;
+    };
+
+    /**
+     * Returns the configured holiday / leave entry for a date, if any.
+     * Weekends are not included here: they come from the workingDays mask.
+     */
+    getNonWorkingDay = (date: Date): NonWorkingDay | undefined => {
+        const holidays = this.$session.CurrentUser?.holidays;
+        if (!holidays?.length) {
+            return undefined;
+        }
+
+        const key = formatDate(date, 'yyyy-MM-dd');
+        return holidays.find((h) => h.date === key);
+    };
+
+    /**
+     * Expected hours to be logged on a given date, honouring weekends,
+     * holidays, full-day leave and half days.
+     */
+    getExpectedHours = (date: Date, hoursPerDay?: number): number => {
+        const fullDay = hoursPerDay ?? this.$session.CurrentUser?.minHours ?? 8;
+        const weekDay = date.getDay();
+        const workingDays = this.$session.CurrentUser?.workingDays || DefaultWorkingDays;
+
+        if (workingDays.indexOf(weekDay) === -1) {
+            return 0;
+        }
+
+        const entry = this.getNonWorkingDay(date);
+        if (!entry) {
+            return fullDay;
+        }
+
+        return entry.isHalfDay ? fullDay / 2 : 0;
     };
 
     getProfileImgUrl = (user: User | { jiraUser?: User }): string => {
@@ -159,6 +203,7 @@ export default class UserUtilsService {
             date: d,
             isHoliday: this.isHoliday(d),
             isFuture: d.getTime() > now,
+            nonWorkingDay: this.getNonWorkingDay(d),
         }));
     }
 

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -45,6 +45,7 @@ export interface SessionUser {
     endOfDay?: string;
     startOfWeek?: number;
     workingDays?: number[];
+    holidays?: NonWorkingDay[];
     commentLength?: number;
     dashboards?: Dashboard[];
     openTicketsJQL?: string;
@@ -388,6 +389,19 @@ export enum SettingsCategory {
     PageSettings = 'PSET',
 }
 
+/**
+ * A single non-working day. Public holidays and personal leave are stored the
+ * same way; only the type differs so they can be told apart in reports.
+ */
+export interface NonWorkingDay {
+    /** Date in yyyy-MM-dd form so it survives JSON round-trips without timezone drift */
+    date: string;
+    name?: string;
+    type: 'holiday' | 'leave';
+    /** Half days still expect some logged time; full days expect none */
+    isHalfDay?: boolean;
+}
+
 export interface GeneralSettings {
     dateFormat: string;
     timeFormat: string;
@@ -398,6 +412,7 @@ export interface GeneralSettings {
     endOfDay: string;
     startOfWeek: number;
     workingDays: number[];
+    holidays?: NonWorkingDay[];
     dataStore?: string;
     OLBT?: string;
     skin?: string;


### PR DESCRIPTION
`UserUtilsService.isHoliday()` only knows weekends — it checks the date's weekday against
the `workingDays` mask and nothing else. Public holidays and personal time off therefore
count as regular working days, so worklog reports and the calendar show them as days with
missing time.

### What this adds

A `holidays` general setting: a list of entries with a date, an optional description, a
type (`holiday` or `leave`) and an optional half-day flag. Managed from a new
**Settings → Holidays** tab.

Two service additions consume it:

- `isHoliday(date)` now also returns true for a configured full-day holiday or leave.
  Half days stay working days — some time is still expected on them.
- `getExpectedHours(date)` is new: it returns the hours actually expected on a date
  (0 for weekends and full days off, half of the daily target for half days, otherwise
  the daily target). Callers that need the *amount* rather than a yes/no can use it
  instead of re-deriving the rule.

Because every existing consumer already funnels through `isHoliday()` — `getDateRange`,
`getDays`, the worklog report day columns, the calendar info events — they pick this up
without further changes.

### Relation to #26

#26 asks for a holiday importer with an API module. This is not that: there is no
external calendar integration here. It adds the underlying concept an importer would
populate, and makes it useful on its own for anyone willing to enter a handful of dates.
Happy to follow up with an importer on top if you want it.

### Storage compatibility

The setting is a normal general setting and defaults to an empty list, so existing
installations behave exactly as before until the user adds an entry.

### How to verify
1. Settings → Holidays → add today's date as a holiday.
2. Open the worklog calendar / a worklog report — the day is no longer treated as one
   with missing hours.
3. Add a date as a half day and confirm half the daily target is expected instead of none.

Refs #26