### PR TITLE
Fix: starting a timer from Bookmarks throws, and timer-driven gadget refresh never fires

### DIFF
--- a/src/common/context.ts
+++ b/src/common/context.ts
@@ -3,5 +3,5 @@ import { createContext } from 'react';
 export const AppContext = createContext({});
 export const AppContextProvider = AppContext.Provider;
 
-export const WorklogContext = createContext({});
-export const WorklogContextProvider = WorklogContext.Provider;
+// WorklogContext was removed: its provider was never mounted, so consumers silently
+// received an empty object. Timer state lives in stores/worklog-store (zustand) instead.

--- a/src/gadgets/DateWiseWorklog.tsx
+++ b/src/gadgets/DateWiseWorklog.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { isToday } from 'date-fns';
+
+import { useWorklogStore } from '@/stores/worklog-store';
 
 import { inject } from '@services';
 
@@ -8,7 +10,6 @@ import { ChangeTracker, showContextMenu } from '@components';
 
 import { GadgetActionType } from '@constants';
 
-import { WorklogContext } from '../common/context';
 import { UserDateWiseWorklog, type DateWiseWorklogItem } from '../components/shared';
 import DateRangePicker from '../controls/DateRangePicker';
 import { formatTs } from '../services/utils-service';
@@ -27,7 +28,7 @@ function DateWiseWorklog(props: BaseGadgetProps) {
 
     const { setIsLoading, addWorklog, editWorklog, performAction, settingsRef, saveSettings } = gadgetHook;
     const { $worklog, $message } = inject('WorklogService', 'MessageService');
-    const worklogContext = useContext(WorklogContext) as any;
+    const { timerEntry, needReload } = useWorklogStore();
 
     const refreshData = useCallback(() => {
         setLastUpdated(new Date());
@@ -125,11 +126,7 @@ function DateWiseWorklog(props: BaseGadgetProps) {
                 editWorklog={editWorklog}
                 setLoader={setIsLoading}
             />
-            <ChangeTracker
-                key={worklogContext?.timerEntry?.key}
-                enabled={!gadgetHook.isLoading && worklogContext?.needReload}
-                onChange={refreshData}
-            />
+            <ChangeTracker key={timerEntry?.key} enabled={!gadgetHook.isLoading && needReload} onChange={refreshData} />
         </GadgetContainer>
     );
 }

--- a/src/gadgets/MyBookmarks.tsx
+++ b/src/gadgets/MyBookmarks.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useWorklogStore } from '@/stores/worklog-store';
 
 import { inject } from '@services';
 
@@ -6,7 +8,6 @@ import { Button, Checkbox, showContextMenu } from '@components';
 
 import { GadgetActionType } from '@constants';
 
-import { WorklogContext } from '../common/context';
 import { Column, NoDataRow, ScrollableTable, TBody, THead } from '../components/shared/ScrollableTable';
 import { Image } from '../controls';
 import Link from '../controls/Link';
@@ -45,7 +46,7 @@ export default function MyBookmarks(props: BaseGadgetProps) {
     const [showAddPopup, setShowAddPopup] = useState(false);
     const selectedTicketRef = useRef<BookmarkItem | null>(null);
 
-    const worklogContext = useContext(WorklogContext) as any;
+    const { getElapsedTimeInSecs, startTimer, pauseTimer, resumeTimer, stopTimer } = useWorklogStore();
 
     const gadgetHook = useBaseGadget(props, {
         title: GadgetTitle.Bookmarks,
@@ -159,28 +160,47 @@ export default function MyBookmarks(props: BaseGadgetProps) {
 
             const menus = [...contextMenu];
 
-            try {
-                const result = worklogContext?.getElapsedTimeInSecs?.();
-                const isCurTicket = result?.key === b.ticketNo;
-                const isRunning = result?.isRunning;
+            const result = getElapsedTimeInSecs();
+            const isCurTicket = result?.key === b.ticketNo;
 
-                if (!isCurTicket) {
-                    menus.push({ label: 'Start timer', icon: 'fa fa-play', command: () => worklogContext.startTimer(b.ticketNo) });
+            if (!isCurTicket) {
+                menus.push({
+                    label: 'Start timer',
+                    icon: 'fa fa-play',
+                    command: () => {
+                        startTimer(b.ticketNo);
+                    },
+                });
+            } else {
+                if (result?.isRunning) {
+                    menus.push({
+                        label: 'Pause timer',
+                        icon: 'fa fa-pause',
+                        command: () => {
+                            pauseTimer();
+                        },
+                    });
                 } else {
-                    if (isRunning) {
-                        menus.push({ label: 'Pause timer', icon: 'fa fa-pause', command: worklogContext.pauseTimer });
-                    } else {
-                        menus.push({ label: 'Resume timer', icon: 'fa fa-play', command: worklogContext.resumeTimer });
-                    }
-                    menus.push({ label: 'Stop timer', icon: 'fa fa-stop', command: worklogContext.stopTimer });
+                    menus.push({
+                        label: 'Resume timer',
+                        icon: 'fa fa-play',
+                        command: () => {
+                            resumeTimer();
+                        },
+                    });
                 }
-            } catch {
-                /* Timer context not available */
+                menus.push({
+                    label: 'Stop timer',
+                    icon: 'fa fa-stop',
+                    command: () => {
+                        stopTimer();
+                    },
+                });
             }
 
             showContextMenu(e, menus);
         },
-        [contextMenu, worklogContext],
+        [contextMenu, getElapsedTimeInSecs, startTimer, pauseTimer, resumeTimer, stopTimer],
     );
 
     const hideAddPopup = useCallback(

--- a/src/gadgets/PendingWorklog.tsx
+++ b/src/gadgets/PendingWorklog.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useWorklogStore } from '@/stores/worklog-store';
 
 import { inject } from '@services';
 
@@ -6,7 +8,6 @@ import { Button, ChangeTracker, Checkbox, showContextMenu } from '@components';
 
 import { GadgetActionType } from '@constants';
 
-import { WorklogContext } from '../common/context';
 import { Column, NoDataRow, ScrollableTable, TBody, THead } from '../components/shared/ScrollableTable';
 import Link from '../controls/Link';
 import { Dialog } from '../dialogs/CommonDialog';
@@ -36,7 +37,7 @@ export default function PendingWorklog(props: BaseGadgetProps) {
     const [selAllChk, setSelAllChk] = useState(true);
     const selectedItemRef = useRef<PendingWorklogItem | null>(null);
 
-    const worklogContext = useContext(WorklogContext) as any;
+    const { timerEntry, needReload } = useWorklogStore();
 
     const gadgetHook = useBaseGadget(props, {
         title: GadgetTitle.PendingWorklog,
@@ -236,11 +237,7 @@ export default function PendingWorklog(props: BaseGadgetProps) {
                 </TBody>
                 <NoDataRow span={7}>No worklog pending to be uploaded!</NoDataRow>
             </ScrollableTable>
-            <ChangeTracker
-                key={worklogContext?.timerEntry?.key}
-                enabled={!gadgetHook.isLoading && worklogContext?.needReload}
-                onChange={refreshData}
-            />
+            <ChangeTracker key={timerEntry?.key} enabled={!gadgetHook.isLoading && needReload} onChange={refreshData} />
         </GadgetContainer>
     );
 }

--- a/src/gadgets/WorklogBarChartGadget.tsx
+++ b/src/gadgets/WorklogBarChartGadget.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useWorklogStore } from '@/stores/worklog-store';
 
 import { ChangeTracker } from '@components';
 
 import { GadgetActionType } from '@constants';
 
-import { WorklogContext } from '../common/context';
 import WorklogBarChart from '../components/shared/worklog-bar-chart';
 import DateRangePicker from '../controls/DateRangePicker';
 
@@ -13,7 +14,7 @@ import { GadgetTitle } from './constants';
 
 function WorklogBarChartGadget(props: BaseGadgetProps) {
     const [lastUpdated, setLastUpdated] = useState<Date | undefined>(undefined);
-    const worklogContext = useContext(WorklogContext) as any;
+    const { timerEntry, needReload } = useWorklogStore();
 
     const gadgetHook = useBaseGadget(props, {
         title: GadgetTitle.WorklogBarChart,
@@ -67,11 +68,7 @@ function WorklogBarChartGadget(props: BaseGadgetProps) {
             customActions={customActions}
         >
             <WorklogBarChart lastUpdated={lastUpdated} settings={settingsRef.current} setLoader={setIsLoading} />
-            <ChangeTracker
-                key={worklogContext?.timerEntry?.key}
-                enabled={!gadgetHook.isLoading && worklogContext?.needReload}
-                onChange={refreshData}
-            />
+            <ChangeTracker key={timerEntry?.key} enabled={!gadgetHook.isLoading && needReload} onChange={refreshData} />
         </GadgetContainer>
     );
 }


### PR DESCRIPTION
`WorklogContextProvider` is exported from `src/common/context.ts` but **never mounted**
anywhere in the component tree, so `useContext(WorklogContext)` always returns the empty
default object `{}`. Four gadgets read timer state and actions off it.

### The visible bug

Right-click a bookmark → **Start timer**:

```
Uncaught TypeError: l.startTimer is not a function
    at Object.command (gadgets-*.js)
```

`MyBookmarks` calls `worklogContext.startTimer(...)` unguarded. What hid this during
development is that the same handler reads the timer *state* through optional chaining
(`worklogContext?.getElapsedTimeInSecs?.()`), which silently returns `undefined` — so the
menu always renders the "Start timer" entry, and only the call throws.

### The silent bug

`DateWiseWorklog`, `PendingWorklog` and `WorklogBarChartGadget` render

```jsx
<ChangeTracker key={worklogContext?.timerEntry?.key}
               enabled={!isLoading && worklogContext?.needReload} />
```

`needReload` is always `undefined` off the empty object, so `ChangeTracker` is never
enabled and **these three gadgets never refresh after a timer stops** — the new worklog
appears only after a manual refresh.

### The fix

All four now read the zustand worklog store directly via `useWorklogStore()`, which is
where the timer state actually lives and is already kept current by `DefaultLayout`
(`loadTracker` on mount, on window focus and over the keep-alive port).

This is not a new pattern: `src/display-controls/TicketDisplay.tsx` already does exactly
this for its own timer context menu, which is why starting a timer from a ticket display
works while starting one from a bookmark does not.

The dead context is removed so it cannot be reached for again; `AppContext` in the same
file is untouched (it has a real provider).

### How to verify
1. Right-click a bookmark → Start timer — previously threw, now starts the timer.
2. With a Daywise Worklog or Worklog Bar Chart gadget on the dashboard, start and stop a
   timer — the gadget refreshes on its own instead of needing the refresh button.
3. Confirm the timer context menu on a bookmark reflects the running timer (Pause/Resume/
   Stop instead of always offering Start).